### PR TITLE
Custom validation messages with localization support

### DIFF
--- a/src/Three.php
+++ b/src/Three.php
@@ -37,6 +37,6 @@ class Three implements Rule
      */
     public function message()
     {
-        return 'Invalid ISO3166-A3 country code.';
+        return __('validation.country3');
     }
 }

--- a/src/Two.php
+++ b/src/Two.php
@@ -37,6 +37,6 @@ class Two implements Rule
      */
     public function message()
     {
-        return __('validation.country');
+        return __('validation.country2');
     }
 }

--- a/src/Two.php
+++ b/src/Two.php
@@ -37,6 +37,6 @@ class Two implements Rule
      */
     public function message()
     {
-        return 'Invalid ISO3166-A2 country code.';
+        return __('validation.country');
     }
 }


### PR DESCRIPTION
This would allow custom validation messages with localization support. Messages would need to be added to lang/{language}/validation.php under 'country2' and 'country3' keys.

'country2' => 'Invalid ISO3166-A2 country code.',
'country3' => 'Invalid ISO3166-A3 country code.',